### PR TITLE
Add Python wheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.otf
 *.woff
 *.woff2
+.venv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "fontheight-wheel"
+version = "0.1.0"
+dependencies = [
+ "fontheight-core",
+ "pyo3",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +287,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -322,6 +336,15 @@ name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "minreq"
@@ -403,12 +426,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -575,6 +667,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "thiserror"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +730,12 @@ name = "unicode-script"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb421b350c9aff471779e262955939f565ec18b86c15364e6bdf0d662ca7c1f"
+
+[[package]]
+name = "unindent"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,8 +267,10 @@ dependencies = [
 name = "fontheight-wheel"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "fontheight-core",
  "pyo3",
+ "static-lang-word-lists",
 ]
 
 [[package]]
@@ -446,6 +448,7 @@ version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
 dependencies = [
+ "anyhow",
  "cfg-if",
  "indoc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "fontheight",
     "fontheight-core",
+    "fontheight-wheel",
     "static-lang-word-lists",
 ]
 

--- a/fontheight-core/src/exemplars.rs
+++ b/fontheight-core/src/exemplars.rs
@@ -1,29 +1,29 @@
 use std::{cmp::Ordering, collections::BinaryHeap};
 
-use crate::Report;
+use crate::WordExtremes;
 
 /// A summary of the lowest lows and highest highs.
 #[derive(Debug, Clone)]
-pub struct ReportSummary<'w> {
-    pub lowest: Vec<Report<'w>>,
-    pub highest: Vec<Report<'w>>,
+pub struct Exemplars<'w> {
+    pub lowest: Vec<WordExtremes<'w>>,
+    pub highest: Vec<WordExtremes<'w>>,
 }
 
 /// A builder to construct a limited size summary from a stream of words. We do
 /// this as an explicit step with a binary heap for assured runtime complexity.
 #[derive(Debug, Clone)]
-pub(crate) struct ReportSummarizer<'w> {
+pub(crate) struct ExemplarCollector<'w> {
     lowest: BinaryHeap<ByLowest<'w>>,
     highest: BinaryHeap<ByHighest<'w>>,
 }
 
 /// Report, but sorted ascending by lowest for a max-heap.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-struct ByLowest<'w>(Report<'w>);
+struct ByLowest<'w>(WordExtremes<'w>);
 
 /// Report, but sorted descending by highest for a min-heap.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-struct ByHighest<'w>(Report<'w>);
+struct ByHighest<'w>(WordExtremes<'w>);
 
 impl Ord for ByLowest<'_> {
     fn cmp(&self, other: &Self) -> Ordering {
@@ -55,7 +55,7 @@ impl PartialOrd for ByHighest<'_> {
     }
 }
 
-impl<'w> ReportSummarizer<'w> {
+impl<'w> ExemplarCollector<'w> {
     /// Build a summary with a maximum number of reports.
     pub(crate) fn new(top_n: usize) -> Self {
         Self {
@@ -65,7 +65,7 @@ impl<'w> ReportSummarizer<'w> {
     }
 
     /// Consider adding a new report, if it is low and/or high enough.
-    pub(crate) fn push(&mut self, elem: Report<'w>) {
+    pub(crate) fn push(&mut self, elem: WordExtremes<'w>) {
         // Store if this report is stronger than the weakest report that would
         // be evicted from the heap to accommodate it.
         let by_lowest = ByLowest(elem);
@@ -90,8 +90,8 @@ impl<'w> ReportSummarizer<'w> {
     }
 
     /// Consume this builder and produce the summary.
-    pub(crate) fn build(self) -> ReportSummary<'w> {
-        ReportSummary {
+    pub(crate) fn build(self) -> Exemplars<'w> {
+        Exemplars {
             lowest: self
                 .lowest
                 .into_sorted_vec()

--- a/fontheight-core/src/locations.rs
+++ b/fontheight-core/src/locations.rs
@@ -14,7 +14,7 @@ impl Location {
     pub const fn user_coords(&self) -> &HashMap<skrifa::Tag, f32> {
         &self.user_coords
     }
-    
+
     pub fn to_skrifa(
         &self,
         font: &skrifa::FontRef,

--- a/fontheight-core/src/locations.rs
+++ b/fontheight-core/src/locations.rs
@@ -4,12 +4,17 @@ use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use skrifa::{raw::collections::int_set::Domain, MetadataProvider};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Location {
     user_coords: HashMap<skrifa::Tag, f32>,
 }
 
 impl Location {
+    #[inline]
+    pub const fn user_coords(&self) -> &HashMap<skrifa::Tag, f32> {
+        &self.user_coords
+    }
+    
     pub fn to_skrifa(
         &self,
         font: &skrifa::FontRef,

--- a/fontheight-core/src/locations.rs
+++ b/fontheight-core/src/locations.rs
@@ -4,15 +4,19 @@ use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use skrifa::{raw::collections::int_set::Domain, MetadataProvider};
 
+pub type SimpleLocation = HashMap<String, f32>;
+
 #[derive(Debug, Clone)]
 pub struct Location {
     user_coords: HashMap<skrifa::Tag, f32>,
 }
 
 impl Location {
-    #[inline]
-    pub const fn user_coords(&self) -> &HashMap<skrifa::Tag, f32> {
-        &self.user_coords
+    pub fn to_simple(&self) -> SimpleLocation {
+        self.user_coords
+            .iter()
+            .map(|(tag, &val)| (tag.to_string(), val))
+            .collect()
     }
 
     pub fn to_skrifa(

--- a/fontheight-core/src/summary.rs
+++ b/fontheight-core/src/summary.rs
@@ -1,0 +1,109 @@
+use std::{cmp::Ordering, collections::BinaryHeap};
+
+use crate::Report;
+
+/// A summary of the lowest lows and highest highs.
+#[derive(Debug, Clone)]
+pub struct ReportSummary<'w> {
+    pub lowest: Vec<Report<'w>>,
+    pub highest: Vec<Report<'w>>,
+}
+
+/// A builder to construct a limited size summary from a stream of words. We do
+/// this as an explicit step with a binary heap for assured runtime complexity.
+#[derive(Debug, Clone)]
+pub(crate) struct ReportSummarizer<'w> {
+    lowest: BinaryHeap<ByLowest<'w>>,
+    highest: BinaryHeap<ByHighest<'w>>,
+}
+
+/// Report, but sorted ascending by lowest for a max-heap.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+struct ByLowest<'w>(Report<'w>);
+
+/// Report, but sorted descending by highest for a min-heap.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+struct ByHighest<'w>(Report<'w>);
+
+impl Ord for ByLowest<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.extremes.lowest.cmp(&other.0.extremes.lowest)
+    }
+}
+
+impl Ord for ByHighest<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0
+            .extremes
+            .highest
+            .cmp(&other.0.extremes.highest)
+            .reverse()
+    }
+}
+
+impl PartialOrd for ByLowest<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        // Defer to Ord.
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialOrd for ByHighest<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        // Defer to Ord.
+        Some(self.cmp(other))
+    }
+}
+
+impl<'w> ReportSummarizer<'w> {
+    /// Build a summary with a maximum number of reports.
+    pub(crate) fn new(top_n: usize) -> Self {
+        Self {
+            lowest: BinaryHeap::with_capacity(top_n),
+            highest: BinaryHeap::with_capacity(top_n),
+        }
+    }
+
+    /// Consider adding a new report, if it is low and/or high enough.
+    pub(crate) fn push(&mut self, elem: Report<'w>) {
+        // Store if this report is stronger than the weakest report that would
+        // be evicted from the heap to accommodate it.
+        let by_lowest = ByLowest(elem);
+        if self.lowest.len() < self.lowest.capacity() {
+            self.lowest.push(by_lowest);
+        } else if let Some(mut weakest_low) = self.lowest.peek_mut() {
+            if by_lowest < *weakest_low {
+                *weakest_low = by_lowest;
+            }
+        }
+
+        // Store if this report is stronger than the weakest report that would
+        // be evicted from the heap to accommodate it.
+        let by_highest = ByHighest(elem);
+        if self.highest.len() < self.highest.capacity() {
+            self.highest.push(by_highest);
+        } else if let Some(mut weakest_high) = self.highest.peek_mut() {
+            if by_highest < *weakest_high {
+                *weakest_high = by_highest;
+            }
+        }
+    }
+
+    /// Consume this builder and produce the summary.
+    pub(crate) fn build(self) -> ReportSummary<'w> {
+        ReportSummary {
+            lowest: self
+                .lowest
+                .into_sorted_vec()
+                .into_iter()
+                .map(|by| by.0)
+                .collect(),
+            highest: self
+                .highest
+                .into_sorted_vec()
+                .into_iter()
+                .map(|by| by.0)
+                .collect(),
+        }
+    }
+}

--- a/fontheight-wheel/Cargo.toml
+++ b/fontheight-wheel/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "fontheight-wheel"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+name = "fontheight"
+crate-type = ["cdylib"]
+
+[dependencies]
+fontheight-core = { version = "0.1.0", path = "../fontheight-core"}
+pyo3 = { version = "0.23.5", features = ["extension-module"] }

--- a/fontheight-wheel/Cargo.toml
+++ b/fontheight-wheel/Cargo.toml
@@ -8,5 +8,13 @@ name = "fontheight"
 crate-type = ["cdylib"]
 
 [dependencies]
+anyhow = "1"
 fontheight-core = { version = "0.1.0", path = "../fontheight-core"}
-pyo3 = { version = "0.23.5", features = ["extension-module"] }
+static-lang-word-lists = { version = "0.1.0", path = "../static-lang-word-lists" }
+
+[dependencies.pyo3]
+version = "0.23.5"
+features = [
+    "extension-module",
+    "anyhow",
+]

--- a/fontheight-wheel/pyproject.toml
+++ b/fontheight-wheel/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "libfontheight"
+dynamic = [
+    "version",
+    "readme",
+    "description",
+    "authors",
+    "license"
+]
+requires-python = ">=3.8"
+
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[tool.maturin]
+profile = "release"
+locked = true

--- a/fontheight-wheel/src/lib.rs
+++ b/fontheight-wheel/src/lib.rs
@@ -5,6 +5,7 @@ use pyo3::{Bound, PyResult, prelude::*, pymodule, types::PyBytes};
 use static_lang_word_lists::DIFFENATOR_LATIN;
 
 #[pyclass(frozen, get_all)]
+#[derive(Debug)]
 struct FontheightReport {
     word: String,
     highest: f64,
@@ -26,6 +27,22 @@ impl FontheightReport {
             highest,
             lowest,
         }
+    }
+}
+
+#[pymethods]
+impl FontheightReport {
+    fn __repr__(&self) -> String {
+        let FontheightReport {
+            word,
+            location,
+            highest,
+            lowest,
+        } = self;
+        format!(
+            "FontheightReport(word=\"{word}\", location={location:?}, \
+             highest={highest}, lowest={lowest})"
+        )
     }
 }
 

--- a/fontheight-wheel/src/lib.rs
+++ b/fontheight-wheel/src/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use fontheight_core::{Location, Report, Reporter, VerticalExtremes};
+use fontheight_core::{Location, Report, Reporter};
 use pyo3::{Bound, PyResult, prelude::*, pymodule, types::PyBytes};
 use static_lang_word_lists::DIFFENATOR_LATIN;
 
@@ -16,7 +16,6 @@ struct FontheightReport {
 impl FontheightReport {
     fn new(report: Report, location: &Location) -> Self {
         let Report { word, extremes } = report;
-        let VerticalExtremes { highest, lowest } = extremes;
         FontheightReport {
             word: word.to_owned(),
             location: location
@@ -24,8 +23,8 @@ impl FontheightReport {
                 .iter()
                 .map(|(tag, &value)| (tag.to_string(), value))
                 .collect(),
-            highest,
-            lowest,
+            highest: extremes.highest(),
+            lowest: extremes.lowest(),
         }
     }
 }

--- a/fontheight-wheel/src/lib.rs
+++ b/fontheight-wheel/src/lib.rs
@@ -1,43 +1,43 @@
-use fontheight_core::{Report, ReportSummary, Reporter, SimpleLocation};
+use fontheight_core::{Exemplars, Reporter, SimpleLocation, WordExtremes};
 use pyo3::{Bound, PyResult, prelude::*, pymodule, types::PyBytes};
 use static_lang_word_lists::DIFFENATOR_LATIN;
 
 #[pyclass(frozen, get_all)]
 #[derive(Debug, Clone)]
-struct FontheightReport {
+struct Report {
     location: SimpleLocation,
     word_list_name: String,
-    exemplars: OwnedReportSummary,
+    exemplars: OwnedExemplars,
 }
 
-#[pyclass(name = "ReportSummary", frozen, get_all)]
+#[pyclass(name = "Exemplars", frozen, get_all)]
 #[derive(Debug, Clone)]
-struct OwnedReportSummary {
-    lowest: Vec<OwnedReport>,
-    highest: Vec<OwnedReport>,
+struct OwnedExemplars {
+    lowest: Vec<OwnedWordExtremes>,
+    highest: Vec<OwnedWordExtremes>,
 }
 
-impl From<ReportSummary<'_>> for OwnedReportSummary {
-    fn from(summary: ReportSummary<'_>) -> Self {
-        let ReportSummary { lowest, highest } = summary;
-        OwnedReportSummary {
-            lowest: lowest.into_iter().map(OwnedReport::from).collect(),
-            highest: highest.into_iter().map(OwnedReport::from).collect(),
+impl From<Exemplars<'_>> for OwnedExemplars {
+    fn from(summary: Exemplars<'_>) -> Self {
+        let Exemplars { lowest, highest } = summary;
+        OwnedExemplars {
+            lowest: lowest.into_iter().map(OwnedWordExtremes::from).collect(),
+            highest: highest.into_iter().map(OwnedWordExtremes::from).collect(),
         }
     }
 }
 
-#[pyclass(name = "Report", frozen, get_all)]
+#[pyclass(name = "WordExtremes", frozen, get_all)]
 #[derive(Debug, Clone)]
-struct OwnedReport {
+struct OwnedWordExtremes {
     word: String,
     lowest: f64,
     highest: f64,
 }
 
-impl From<Report<'_>> for OwnedReport {
-    fn from(report: Report<'_>) -> Self {
-        OwnedReport {
+impl From<WordExtremes<'_>> for OwnedWordExtremes {
+    fn from(report: WordExtremes<'_>) -> Self {
+        OwnedWordExtremes {
             word: report.word.to_owned(),
             lowest: report.extremes.lowest(),
             highest: report.extremes.highest(),
@@ -49,17 +49,17 @@ impl From<Report<'_>> for OwnedReport {
 fn get_min_max_extremes(
     font_bytes: Py<PyBytes>,
     n: usize,
-) -> anyhow::Result<Vec<FontheightReport>> {
+) -> anyhow::Result<Vec<Report>> {
     let bytes = Python::with_gil(|py| font_bytes.as_bytes(py));
     let reporter = Reporter::new(bytes)?;
     let locations = reporter.interesting_locations();
 
     locations
         .iter()
-        .map(|location| -> anyhow::Result<FontheightReport> {
+        .map(|location| -> anyhow::Result<Report> {
             let report_iter =
                 reporter.check_location(location, &DIFFENATOR_LATIN)?;
-            Ok(FontheightReport {
+            Ok(Report {
                 location: location.to_simple(),
                 word_list_name: DIFFENATOR_LATIN.name().to_owned(),
                 exemplars: report_iter.collect_min_max_extremes(n).into(),
@@ -70,9 +70,9 @@ fn get_min_max_extremes(
 
 #[pymodule]
 fn fontheight(module: &Bound<'_, PyModule>) -> PyResult<()> {
-    module.add_class::<FontheightReport>()?;
-    module.add_class::<OwnedReportSummary>()?;
-    module.add_class::<OwnedReport>()?;
+    module.add_class::<Report>()?;
+    module.add_class::<OwnedExemplars>()?;
+    module.add_class::<OwnedWordExtremes>()?;
     module.add_function(wrap_pyfunction!(get_min_max_extremes, module)?)?;
     Ok(())
 }

--- a/fontheight-wheel/src/lib.rs
+++ b/fontheight-wheel/src/lib.rs
@@ -1,0 +1,13 @@
+use pyo3::{pymodule, Bound, PyResult};
+use pyo3::prelude::*;
+
+#[pyfunction]
+fn hello_world() {
+    println!("Hello world");
+}
+
+#[pymodule]
+fn fontheight(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_function(wrap_pyfunction!(hello_world, module)?)?;
+    Ok(())
+}

--- a/fontheight-wheel/src/lib.rs
+++ b/fontheight-wheel/src/lib.rs
@@ -1,13 +1,54 @@
-use pyo3::{pymodule, Bound, PyResult};
-use pyo3::prelude::*;
+use std::collections::HashMap;
+
+use fontheight_core::{Location, Report, Reporter, VerticalExtremes};
+use pyo3::{Bound, PyResult, prelude::*, pymodule, types::PyBytes};
+use static_lang_word_lists::DIFFENATOR_LATIN;
+
+#[pyclass(frozen, get_all)]
+struct FontheightReport {
+    word: String,
+    highest: f64,
+    lowest: f64,
+    location: HashMap<String, f32>,
+}
+
+impl FontheightReport {
+    fn new(report: Report, location: &Location) -> Self {
+        let Report { word, extremes } = report;
+        let VerticalExtremes { highest, lowest } = extremes;
+        FontheightReport {
+            word: word.to_owned(),
+            location: location
+                .user_coords()
+                .iter()
+                .map(|(tag, &value)| (tag.to_string(), value))
+                .collect(),
+            highest,
+            lowest,
+        }
+    }
+}
 
 #[pyfunction]
-fn hello_world() {
-    println!("Hello world");
+fn get_min_max_extremes(
+    font_bytes: Py<PyBytes>,
+    n: usize,
+) -> anyhow::Result<Vec<FontheightReport>> {
+    let bytes = Python::with_gil(|py| font_bytes.as_bytes(py));
+    let mut reporter = Reporter::new(bytes)?;
+    let locations = reporter.interesting_locations();
+    let reports = reporter
+        .check_location(&locations[0], &DIFFENATOR_LATIN)?
+        .map(|report| FontheightReport::new(report, &locations[0]))
+        .take(n)
+        .collect::<Vec<_>>();
+
+    Ok(reports)
 }
 
 #[pymodule]
 fn fontheight(module: &Bound<'_, PyModule>) -> PyResult<()> {
-    module.add_function(wrap_pyfunction!(hello_world, module)?)?;
+    module.add_class::<FontheightReport>()?;
+    module.add_function(wrap_pyfunction!(get_min_max_extremes, module)?)?;
     Ok(())
 }

--- a/fontheight/src/main.rs
+++ b/fontheight/src/main.rs
@@ -30,6 +30,10 @@ fn main() -> ExitCode {
 struct Args {
     /// The TTF to analyze
     font_path: PathBuf,
+
+    /// The number of words to log
+    #[arg(short, long)]
+    results: usize,
 }
 
 fn _main() -> anyhow::Result<()> {
@@ -42,7 +46,7 @@ fn _main() -> anyhow::Result<()> {
     let locations = reporter.interesting_locations();
     let reports = reporter
         .check_location(&locations[0], &DIFFENATOR_LATIN)?
-        .collect::<Vec<_>>();
+        .collect_n_extremes(args.results);
 
     info!("{reports:#?}");
     Ok(())

--- a/fontheight/src/main.rs
+++ b/fontheight/src/main.rs
@@ -42,11 +42,11 @@ fn _main() -> anyhow::Result<()> {
     let font_bytes =
         fs::read(&args.font_path).context("failed to read font file")?;
 
-    let mut reporter = Reporter::new(&font_bytes)?;
+    let reporter = Reporter::new(&font_bytes)?;
     let locations = reporter.interesting_locations();
     let reports = reporter
         .check_location(&locations[0], &DIFFENATOR_LATIN)?
-        .collect_n_extremes(args.results);
+        .collect_min_max_extremes(args.results);
 
     info!("{reports:#?}");
     Ok(())


### PR DESCRIPTION
To present a simplified API (compared to the CLI) sufficient for writing a Fontbakery check

Crate is named `fontheight-wheel`. Package name on PyPI is currently `libfontheight`. Imported as `fontheight`. The `libfontheight` name was chosen in case we want to have a separate wheel later to distribute the `fontheight` CLI crate

Limitations unlikely to be addressed in this PR:
- Hardcoded to Diffenator Latin word list

TODO:
- [x] Take N biggest & smallest extremes (currently first N reports for sake of testing)
- [x] Check all locations
- [x] Support passing something path-like instead of bytes