### PR TITLE
Quick optimisations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,6 +691,7 @@ dependencies = [
  "minreq",
  "phf",
  "rayon",
+ "rustybuzz",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
 [workspace.dependencies]
 log = "0.4.25"
 rayon = "1.10"
+rustybuzz = "0.20.1"
 thiserror = "2"
 
 [profile.release]

--- a/fontheight-core/Cargo.toml
+++ b/fontheight-core/Cargo.toml
@@ -17,7 +17,7 @@ kurbo = "0.11.1"
 log = { workspace = true }
 ordered-float = "4.6"
 rayon = { workspace = true, optional = true }
-rustybuzz = "0.20.1"
+rustybuzz = { workspace = true }
 skrifa = "0.26.5"
 thiserror = { workspace = true }
 static-lang-word-lists = { version = "0.1.0", path = "../static-lang-word-lists" }

--- a/static-lang-word-lists/Cargo.toml
+++ b/static-lang-word-lists/Cargo.toml
@@ -12,6 +12,7 @@ brotli-decompressor = "4"
 log = { workspace = true }
 phf = { version = "0.11.3", features = ["macros"] }
 rayon = { workspace = true, optional = true }
+rustybuzz = { workspace = true }
 thiserror = { workspace = true }
 
 [build-dependencies]

--- a/static-lang-word-lists/src/word_lists.rs
+++ b/static-lang-word-lists/src/word_lists.rs
@@ -5,6 +5,7 @@ use std::{
     slice,
 };
 
+use rustybuzz::{script, Direction, Script};
 use thiserror::Error;
 
 #[derive(Debug)]
@@ -69,6 +70,20 @@ impl WordList {
     #[inline]
     pub fn get(&self, index: usize) -> Option<&str> {
         self.words.get(index).map(|word| word.as_str())
+    }
+
+    pub fn properties(&self) -> Option<(Direction, Script)> {
+        for word in self.words.iter().take(20) {
+            let mut buffer = rustybuzz::UnicodeBuffer::new();
+            buffer.push_str(word);
+            buffer.guess_segment_properties();
+            if buffer.direction() != Direction::Invalid
+                && buffer.script() != script::UNKNOWN
+            {
+                return Some((buffer.direction(), buffer.script()));
+            }
+        }
+        None
     }
 }
 


### PR DESCRIPTION
Made based on some low hanging optimisations we saw that helped #44 perform so well

- [x] shaping plan at runtime, assuming a word list is of a single script (true while we only have diffenator word lists)
- [ ] codepoint coverage cache for font to easily discount words that can't be shaped