### PR TITLE
Word lists refactor

### DIFF
--- a/static-lang-word-lists/README.md
+++ b/static-lang-word-lists/README.md
@@ -32,3 +32,5 @@ To build using local files, set the `STATIC_LANG_WORD_LISTS_LOCAL` environment v
 ## Credits
 
 Diffenator wordlists are from [diffenator2](https://github.com/googlefonts/diffenator2)
+
+Emoji wordlists are from [unicode.org](https://home.unicode.org/)

--- a/static-lang-word-lists/build.rs
+++ b/static-lang-word-lists/build.rs
@@ -94,6 +94,10 @@ fn main() {
                     .expect("metadata file was not UTF-8");
                     let ident = name.to_shouty_snake_case();
                     let bytes = get_a_file(path, wordlist_source_dir);
+                    // Validate the bytes are UTF-8 now so we don't need to at
+                    // runtime
+                    str::from_utf8(&bytes)
+                        .expect("word list should be valid UTF-8");
                     let br_path = compress(&bytes, path);
 
                     let mut codegen_file = codegen_file.lock().unwrap();

--- a/static-lang-word-lists/build.rs
+++ b/static-lang-word-lists/build.rs
@@ -42,9 +42,9 @@ fn main() {
 
     writeln!(
         &mut map_file,
-        r#"#[doc = "A lookup map for the crate-provided [`WordList`]s. Maps [`WordList`] names to the corresponding static [`LazyWordList`]."]
-        pub static LOOKUP_TABLE: ::phf::Map<&'static str, &'static
-         ::std::sync::LazyLock<crate::WordList>> = ::phf::phf_map! {{"#
+        r#"#[doc = "A lookup map for the crate-provided [`WordList`]s. Maps their names to the corresponding static [`WordList`]."]
+        pub static LOOKUP_TABLE: ::phf::Map<&'static str, &'static crate::WordList> =
+            ::phf::phf_map! {{"#
     )
     .unwrap_or_else(|err| panic!("failed to write to map_codeden.rs: {err}"));
     let map_file = Mutex::new(map_file);

--- a/static-lang-word-lists/src/word_lists.rs
+++ b/static-lang-word-lists/src/word_lists.rs
@@ -125,6 +125,7 @@ impl WordList {
         }
     }
 
+    // Used by wordlist! {}
     #[must_use]
     pub(crate) const fn new_lazy(
         metadata: LazyLock<WordListMetadata>,
@@ -134,6 +135,15 @@ impl WordList {
             metadata: EagerOrLazy::Lazy(metadata),
             words: EagerOrLazy::Lazy(words),
         }
+    }
+
+    // Used by build script when building for docs.rs
+    #[cfg(docsrs)]
+    pub(crate) const fn stub() -> Self {
+        Self::new_lazy(
+            LazyLock::new(|| unreachable!()),
+            LazyLock::new(|| unreachable!()),
+        )
     }
 
     /// Get the name of the word list.


### PR DESCRIPTION
Moves the lazy-loading nature of the word lists internal to them. This allows us to independently load metadata and the word list itself, which fixes #62. It is a **breaking change**.

The build script now detects when we're building for docs.rs and disables downloading, instead stubbing the word lists, which fixes #60.