### PR TITLE
Fix crates depending on `static-lang-word-lists` building

### DIFF
--- a/static-lang-word-lists/src/word_lists.rs
+++ b/static-lang-word-lists/src/word_lists.rs
@@ -137,8 +137,8 @@ impl WordList {
         }
     }
 
-    // Used by build script when building for docs.rs
-    #[cfg(docsrs)]
+    // Used by build script when building on docs.rs
+    #[allow(dead_code)]
     pub(crate) const fn stub() -> Self {
         Self::new_lazy(
             LazyLock::new(|| unreachable!()),


### PR DESCRIPTION
More related to #60, the `#[cfg(docsrs)]` only applies to the top-level crate being built, and thus for e.g. `fontheight` the `WordList::stub` method isn't built and thus the crate fails to compile, [like this](https://docs.rs/crate/fontheight/0.1.4/builds/2493444)